### PR TITLE
Validate thread safety for api calls

### DIFF
--- a/api/AltV.Net.Async/AltVAsync.cs
+++ b/api/AltV.Net.Async/AltVAsync.cs
@@ -9,6 +9,9 @@ namespace AltV.Net.Async
         private readonly TaskFactory taskFactory;
         private readonly TickScheduler scheduler;
         private readonly Thread mainThread;
+        internal Thread TickThread;
+
+        public Action TickDelegate;
 
         public AltVAsync(ITickSchedulerFactory tickSchedulerFactory)
         {
@@ -23,9 +26,16 @@ namespace AltV.Net.Async
                 CancellationToken.None, TaskCreationOptions.DenyChildAttach,
                 TaskContinuationOptions.None, scheduler);
             AltAsync.Setup(this);
+            TickDelegate = FirstTick;
         }
 
-        internal void Tick()
+        private void FirstTick()
+        {
+            TickThread = Thread.CurrentThread;
+            TickDelegate = Tick;
+        }
+
+        private void Tick()
         {
             scheduler.Tick();
         }

--- a/api/AltV.Net.Async/AsyncModule.cs
+++ b/api/AltV.Net.Async/AsyncModule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Loader;
+using System.Threading;
 using System.Threading.Tasks;
 using AltV.Net.Async.Events;
 using AltV.Net.Data;
@@ -88,6 +89,11 @@ namespace AltV.Net.Async
             checkpointPool, voiceChannelPool, colShapePool, nativeResourcePool)
         {
             AltAsync.Setup(this);
+        }
+
+        public override bool IsMainThread()
+        {
+            return AltAsync.AltVAsync.TickThread == Thread.CurrentThread || base.IsMainThread();
         }
 
         public override void OnCheckPointEvent(ICheckpoint checkpoint, IEntity entity, bool state)

--- a/api/AltV.Net.Async/AsyncResource.cs
+++ b/api/AltV.Net.Async/AsyncResource.cs
@@ -19,7 +19,7 @@ namespace AltV.Net.Async
 
         public override void OnTick()
         {
-            altVAsync.Tick();
+            altVAsync.TickDelegate();
         }
 
         public override IBaseEntityPool GetBaseEntityPool(IEntityPool<IPlayer> playerPool,

--- a/api/AltV.Net.Host/Diagnostics/Extensions.cs
+++ b/api/AltV.Net.Host/Diagnostics/Extensions.cs
@@ -1,6 +1,11 @@
 using System;
 using System.IO;
 using System.Text;
+#if DEBUG
+using AltV.Net.Host.Diagnostics.Eventing;
+using System.Runtime.InteropServices;
+
+#endif
 
 namespace AltV.Net.Host.Diagnostics
 {

--- a/api/AltV.Net/Elements/Entities/BaseObject.cs
+++ b/api/AltV.Net/Elements/Entities/BaseObject.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using AltV.Net.Elements.Args;
+using AltV.Net.Exceptions;
 
 namespace AltV.Net.Elements.Entities
 {
@@ -125,12 +129,21 @@ namespace AltV.Net.Elements.Entities
 
         public virtual void CheckIfEntityExists()
         {
+            CheckIfCallIsValid();
             if (Exists)
             {
                 return;
             }
 
             throw new BaseObjectRemovedException(this);
+        }
+
+        [Conditional("DEBUG")]
+        public void CheckIfCallIsValid([CallerMemberName] string callerName = "")
+        {
+            if (Alt.Module.IsMainThread()) return;
+            if (Monitor.IsEntered(this)) return;
+            throw new IllegalThreadException(this, callerName);
         }
 
         public override int GetHashCode()

--- a/api/AltV.Net/Elements/Entities/Entity.cs
+++ b/api/AltV.Net/Elements/Entities/Entity.cs
@@ -46,6 +46,7 @@ namespace AltV.Net.Elements.Entities
 
         public override void CheckIfEntityExists()
         {
+            CheckIfCallIsValid();
             if (Exists) return;
 
             throw new EntityRemovedException(this);

--- a/api/AltV.Net/Elements/Entities/WorldObject.cs
+++ b/api/AltV.Net/Elements/Entities/WorldObject.cs
@@ -14,6 +14,7 @@ namespace AltV.Net.Elements.Entities
 
         public override void CheckIfEntityExists()
         {
+            CheckIfCallIsValid();
             if (Exists)
             {
                 return;

--- a/api/AltV.Net/Exceptions/IllegalThreadException.cs
+++ b/api/AltV.Net/Exceptions/IllegalThreadException.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using AltV.Net.Elements.Entities;
+
+namespace AltV.Net.Exceptions
+{
+    public class IllegalThreadException : Exception
+    {
+        public IllegalThreadException(IBaseObject baseObject, string callerName) : base(
+            $"{callerName} from {baseObject} called in wrong thread with name {Thread.CurrentThread.Name} and id {Thread.CurrentThread.ManagedThreadId}")
+        {
+        }
+    }
+}

--- a/api/AltV.Net/Module.cs
+++ b/api/AltV.Net/Module.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Threading;
 using AltV.Net.Data;
 using AltV.Net.Elements.Args;
 using AltV.Net.Elements.Entities;
@@ -134,6 +135,8 @@ namespace AltV.Net
 
         internal readonly LinkedList<GCHandle> functionExportHandles = new LinkedList<GCHandle>();
 
+        private readonly Thread MainThread;
+
         public Module(IServer server, AssemblyLoadContext assemblyLoadContext,
             INativeResource moduleResource, IBaseBaseObjectPool baseBaseObjectPool,
             IBaseEntityPool baseEntityPool, IEntityPool<IPlayer> playerPool,
@@ -157,6 +160,12 @@ namespace AltV.Net
             VoiceChannelPool = voiceChannelPool;
             ColShapePool = colShapePool;
             NativeResourcePool = nativeResourcePool;
+            MainThread = Thread.CurrentThread;
+        }
+
+        public virtual bool IsMainThread()
+        {
+            return Thread.CurrentThread == MainThread;
         }
 
         public Assembly LoadAssemblyFromName(AssemblyName assemblyName)


### PR DESCRIPTION
This adds debug checks to validate that the current thread is allowed to call the current api.
This won't affect the performance because the debug checks are only injected in debug mode.