### PR TITLE
Patch 2

### DIFF
--- a/docs/articles/loop-all.md
+++ b/docs/articles/loop-all.md
@@ -10,6 +10,7 @@ There are two callback interfaces to implement.
 The callback gets executed inside of an own task and therefore is awaitable.
 Use this callback class either when you have to execute asynchronous code inside the loop or when the loop call itself gets executed asynchronously (not in main thread).
 The entity object parameter by using this callback class is validated and it is safe to be used outside of the main thread without need of using lock statements.
+Remember that you have to inherit your resource class from ```AsyncResource``` (AltAsync package) instead of ```Resource```, otherwise you don't have entity validation.
 
 2. ```IBaseObjectCallback``` is used for none async code.
 The loop execution also blocks the execution on the main thread.
@@ -20,16 +21,20 @@ Technically both callbacks, no mather the interface can be called in async code.
 This example is for IPlayer's but can be used for ```IVehicle```, ```IBlip```, ```ICheckpoint```, ```IColShape``` and ```IVoiceChannel``` as well.
 
 ```csharp
-class MyPlayerCallback: IBaseObjectCallback<IPlayer>
+class MyPlayerCallback
+    : IBaseObjectCallback<IPlayer>
 {
-    public void OnBaseObject(IPlayer player) {
+    public void OnBaseObject(IPlayer player)
+    {
         CheckPlayerPosition(player.Position);
     }
 }
 
-class MyPlayerSaveToDBCallback: IAsyncBaseObjectCallback<IPlayer>
+class MyPlayerSaveToDBCallback
+    : IAsyncBaseObjectCallback<IPlayer>
 {
-    public async Task OnBaseObject(IPlayer player) {
+    public async Task OnBaseObject(IPlayer player)
+    {
         var dbPlayer = await LoadPlayerFromDb(player.Id);
         await SavePlayer(dbPlayer);
     }
@@ -66,37 +71,37 @@ Just keep in mind that using classes is better in performance than using lambda 
 
 ```csharp
 public class FunctionCallback<T>
-	: IBaseObjectCallback<T>
-	where T : IBaseObject
+    : IBaseObjectCallback<T>
+    where T : IBaseObject
 {
-	private readonly Action<T> _callback;
+    private readonly Action<T> _callback;
 
-	public FunctionCallback(Action<T> callback)
-	{
-		_callback = callback;
-	}
+    public FunctionCallback(Action<T> callback)
+    {
+        _callback = callback;
+    }
 
-	public void OnBaseObject(T baseObject)
-	{
-		_callback(baseObject);
-	}
+    public void OnBaseObject(T baseObject)
+    {
+        _callback(baseObject);
+    }
 }
 
 public class AsyncFunctionCallback<T>
-	: IAsyncBaseObjectCallback<T>
-	where T : IBaseObject
+    : IAsyncBaseObjectCallback<T>
+    where T : IBaseObject
 {
-	private readonly Func<T, Task> _callback;
+    private readonly Func<T, Task> _callback;
 
-	public AsyncFunctionCallback(Func<T, Task> callback)
-	{
-		_callback = callback;
-	}
+    public AsyncFunctionCallback(Func<T, Task> callback)
+    {
+        _callback = callback;
+    }
 
-	public Task OnBaseObject(T baseObject)
-	{
-		return _callback(baseObject);
-	}
+    public Task OnBaseObject(T baseObject)
+    {
+        return _callback(baseObject);
+    }
 }
 ```
 
@@ -114,6 +119,7 @@ Alt.ForEachPlayers(callback);
 var asyncCallback = new AsyncFunctionCallback<IPlayer>(async (player) => {
     // do something
     Alt.Log(player.Name);
+    await Task.CompletedTask; // you need at least one await statement in async methods
 });
 
 Alt.ForEachPlayers(asyncCallback);


### PR DESCRIPTION
- Improved order of documentation: Describe sync callback variant first
- Added note about the need to use AltAsync package
- Added real async example for lambda implementation as also described before in class implementation
- Added ```await Task.CompletedTask``` in the example where no other await statement is needed. This is required to prevent faulted async state machine