### PR TITLE
fix type by BaseObjectRemovedException

### DIFF
--- a/api/AltV.Net/Elements/Entities/BaseObject.cs
+++ b/api/AltV.Net/Elements/Entities/BaseObject.cs
@@ -48,15 +48,15 @@ namespace AltV.Net.Elements.Entities
 
         protected BaseObject(IServer server, IntPtr nativePointer, BaseObjectType type)
         {
+            Type = type;
+            Server = server;
+            NativePointer = nativePointer;
+            exists = true;
+            
             if (nativePointer == IntPtr.Zero)
             {
                 throw new BaseObjectRemovedException(this);
             }
-
-            Server = server;
-            NativePointer = nativePointer;
-            Type = type;
-            exists = true;
         }
 
         public void SetMetaData(string key, object value)

--- a/api/AltV.Net/Elements/Entities/BaseObject.cs
+++ b/api/AltV.Net/Elements/Entities/BaseObject.cs
@@ -48,9 +48,9 @@ namespace AltV.Net.Elements.Entities
 
         protected BaseObject(IServer server, IntPtr nativePointer, BaseObjectType type)
         {
-            Type = type;
             Server = server;
             NativePointer = nativePointer;
+            Type = type;
             
             if (nativePointer == IntPtr.Zero)
             {

--- a/api/AltV.Net/Elements/Entities/BaseObject.cs
+++ b/api/AltV.Net/Elements/Entities/BaseObject.cs
@@ -51,12 +51,13 @@ namespace AltV.Net.Elements.Entities
             Type = type;
             Server = server;
             NativePointer = nativePointer;
-            exists = true;
             
             if (nativePointer == IntPtr.Zero)
             {
                 throw new BaseObjectRemovedException(this);
             }
+            
+            exists = true;
         }
 
         public void SetMetaData(string key, object value)

--- a/docs/articles/entity-sync.md
+++ b/docs/articles/entity-sync.md
@@ -11,7 +11,7 @@ https://www.nuget.org/packages/AltV.Net.EntitySync.ServerEvent // A optional pac
 ## Configure the Entity Sync
 
 ```csharp
-AltEntitySync.Init(1, (threadId) => 100, (threadId) => false,
+AltEntitySync.Init(1, (syncRate) => 100, (threadId) => false,
    (threadCount, repository) => new ServerEventNetworkLayer(threadCount, repository),
    (entity, threadCount) => (entity.Id % threadCount), 
    (entityId, entityType, threadCount) => (entityId % threadCount),

--- a/docs/articles/entity-sync.md
+++ b/docs/articles/entity-sync.md
@@ -11,7 +11,7 @@ https://www.nuget.org/packages/AltV.Net.EntitySync.ServerEvent // A optional pac
 ## Configure the Entity Sync
 
 ```csharp
-AltEntitySync.Init(1, (syncRate) => 100, (threadId) => false,
+AltEntitySync.Init(1, (threadId) => 100, (threadId) => false,
    (threadCount, repository) => new ServerEventNetworkLayer(threadCount, repository),
    (entity, threadCount) => (entity.Id % threadCount), 
    (entityId, entityType, threadCount) => (entityId % threadCount),


### PR DESCRIPTION
Currently, when an entity cannot be created, AltV.Net.Elements.Entities.BaseObjectRemovedException is thrown every time with the wrong type in the stack trace:

In this example, a vehicle is attempted to be created, and the exception logs type player. This is because the type is not set in the BaseObject before the exception is thrown.

AltV.Net.Elements.Entities.BaseObjectRemovedException: BaseObject(Type: Player) got deleted.
  at AltV.Net.Elements.Entities.BaseObject..ctor(IServer server, IntPtr nativePointer, BaseObjectType type)
  at AltV.Net.Elements.Entities.WorldObject..ctor(IServer server, IntPtr nativePointer, BaseObjectType type)
  at AltV.Net.Elements.Entities.Entity..ctor(IServer server, IntPtr nativePointer, BaseObjectType type, UInt16 id)
  at AltV.Net.Elements.Entities.Vehicle..ctor(IServer server, IntPtr nativePointer, UInt16 id)
  at AltV.Net.Elements.Entities.Vehicle..ctor(IServer server, UInt32 model, Position position, Rotation rotation)