### PR TITLE
Added BaseObjectCreate & BaseObjectRemove events

### DIFF
--- a/api/AltV.Net.Async/AltAsync.RegisterEvents.cs
+++ b/api/AltV.Net.Async/AltAsync.RegisterEvents.cs
@@ -417,8 +417,35 @@ namespace AltV.Net.Async
                                             return currScriptFunction.CallAsync();
                                         };
                                     break;
+                                case ScriptEventType.BaseObjectCreate:
+                                    scriptFunction = ScriptFunction.Create(eventMethodDelegate,
+                                        new[]
+                                        {
+                                            typeof(IBaseObject)
+                                        }, true);
+                                    if (scriptFunction == null) return;
+                                    OnBaseObjectCreate += (baseObject) =>
+                                    {
+                                        var currScriptFunction = scriptFunction.Clone();
+                                        currScriptFunction.Set(baseObject);
+                                        return currScriptFunction.CallAsync();
+                                    };
+                                    break;
+                                case ScriptEventType.BaseObjectRemove:
+                                    scriptFunction = ScriptFunction.Create(eventMethodDelegate,
+                                        new[]
+                                        {
+                                            typeof(IBaseObject)
+                                        }, true);
+                                    if (scriptFunction == null) return;
+                                    OnBaseObjectRemove += (baseObject) =>
+                                    {
+                                        var currScriptFunction = scriptFunction.Clone();
+                                        currScriptFunction.Set(baseObject);
+                                        return currScriptFunction.CallAsync();
+                                    };
+                                    break;
                             }
-
                             break;
                         case AsyncServerEventAttribute @event:
                             var serverEventName = @event.Name ?? eventMethod.Name;

--- a/api/AltV.Net.Async/AltAsync.cs
+++ b/api/AltV.Net.Async/AltAsync.cs
@@ -170,6 +170,18 @@ namespace AltV.Net.Async
             remove => Module.VehicleDamageAsyncEventHandler.Remove(value);
         }
         
+        public static event BaseObjectCreateAsyncDelegate OnBaseObjectCreate
+        {
+            add => Module.BaseObjectCreateAsyncEventHandler.Add(value);
+            remove => Module.BaseObjectCreateAsyncEventHandler.Remove(value);
+        }
+        
+        public static event BaseObjectRemoveAsyncDelegate OnBaseObjectRemove
+        {
+            add => Module.BaseObjectRemoveAsyncEventHandler.Add(value);
+            remove => Module.BaseObjectRemoveAsyncEventHandler.Remove(value);
+        }
+        
         public static async void Log(string message)
         {
             var messagePtr = AltNative.StringUtils.StringToHGlobalUtf8(message);

--- a/api/AltV.Net.Async/AsyncModule.cs
+++ b/api/AltV.Net.Async/AsyncModule.cs
@@ -98,6 +98,12 @@ namespace AltV.Net.Async
         
         internal readonly AsyncEventHandler<VehicleDamageAsyncDelegate> VehicleDamageAsyncEventHandler =
             new AsyncEventHandler<VehicleDamageAsyncDelegate>();
+        
+        internal readonly AsyncEventHandler<BaseObjectCreateAsyncDelegate> BaseObjectCreateAsyncEventHandler =
+            new AsyncEventHandler<BaseObjectCreateAsyncDelegate>();
+        
+        internal readonly AsyncEventHandler<BaseObjectRemoveAsyncDelegate> BaseObjectRemoveAsyncEventHandler =
+            new AsyncEventHandler<BaseObjectRemoveAsyncDelegate>();
 
         public AsyncModule(IServer server, AssemblyLoadContext assemblyLoadContext, INativeResource moduleResource,
             IBaseBaseObjectPool baseBaseObjectPool, IBaseEntityPool baseEntityPool, IEntityPool<IPlayer> playerPool,
@@ -720,6 +726,34 @@ namespace AltV.Net.Async
                 sourceEntityRef.DebugCountDown();
                 sourceEntityRef.Dispose();
                 targetVehicleRef.Dispose();
+            });
+        }
+
+        public override void OnBaseObjectCreateEvent(IBaseObject baseObject)
+        {
+            base.OnBaseObjectCreateEvent(baseObject);
+            if (!BaseObjectCreateAsyncEventHandler.HasEvents()) return;
+            var baseObjectRef = new BaseObjectRef(baseObject);
+            Task.Run(async () =>
+            {
+                baseObjectRef.DebugCountUp();
+                await BaseObjectCreateAsyncEventHandler.CallAsync(@delegate => @delegate(baseObject));
+                baseObjectRef.DebugCountDown();
+                baseObjectRef.Dispose();
+            });
+        }
+
+        public override void OnBaseObjectRemoveEvent(IBaseObject baseObject)
+        {
+            base.OnBaseObjectRemoveEvent(baseObject);
+            if (!BaseObjectCreateAsyncEventHandler.HasEvents()) return;
+            var baseObjectRef = new BaseObjectRef(baseObject);
+            Task.Run(async () =>
+            {
+                baseObjectRef.DebugCountUp();
+                await BaseObjectRemoveAsyncEventHandler.CallAsync(@delegate => @delegate(baseObject));
+                baseObjectRef.DebugCountDown();
+                baseObjectRef.Dispose();
             });
         }
 

--- a/api/AltV.Net.Async/Events/Events.cs
+++ b/api/AltV.Net.Async/Events/Events.cs
@@ -61,4 +61,8 @@ namespace AltV.Net.Async.Events
     public delegate Task VehicleDetachAsyncDelegate(IVehicle target, IVehicle detachedVehicle);
     
     public delegate Task VehicleDamageAsyncDelegate(IVehicle target, IEntity attacker, uint bodyHealthDamage, uint additionalBodyHealthDamage, uint engineHealthDamage, uint petrolTankDamage, uint weaponHash);
+
+    public delegate Task BaseObjectCreateAsyncDelegate(IBaseObject baseObject);
+    
+    public delegate Task BaseObjectRemoveAsyncDelegate(IBaseObject baseObject);
 }

--- a/api/AltV.Net/Alt.Events.cs
+++ b/api/AltV.Net/Alt.Events.cs
@@ -224,5 +224,17 @@ namespace AltV.Net
             add => Module.VehicleDamageEventHandler.Add(value);
             remove => Module.VehicleDamageEventHandler.Remove(value);
         }
+        
+        public static event BaseObjectCreateDelegate OnBaseObjectCreate
+        {
+            add => Module.BaseObjectCreateEventHandler.Add(value);
+            remove => Module.BaseObjectCreateEventHandler.Remove(value);
+        }
+        
+        public static event BaseObjectRemoveDelegate OnBaseObjectRemove
+        {
+            add => Module.BaseObjectRemoveEventHandler.Add(value);
+            remove => Module.BaseObjectRemoveEventHandler.Remove(value);
+        }
     }
 }

--- a/api/AltV.Net/Alt.RegisterEvents.cs
+++ b/api/AltV.Net/Alt.RegisterEvents.cs
@@ -436,6 +436,30 @@ namespace AltV.Net
                                             scriptFunction.Set(weaponHash);
                                         };
                                     break;
+                                case ScriptEventType.BaseObjectCreate:
+                                    scriptFunction = ScriptFunction.Create(eventMethodDelegate,
+                                        new[]
+                                        {
+                                            typeof(IBaseObject)
+                                        });
+                                    if (scriptFunction == null) return;
+                                    OnBaseObjectCreate += (baseObject) =>
+                                    {
+                                        scriptFunction.Set(baseObject);
+                                    };
+                                    break;
+                                case ScriptEventType.BaseObjectRemove:
+                                    scriptFunction = ScriptFunction.Create(eventMethodDelegate,
+                                        new[]
+                                        {
+                                            typeof(IBaseObject)
+                                        });
+                                    if (scriptFunction == null) return;
+                                    OnBaseObjectRemove += (baseObject) =>
+                                    {
+                                        scriptFunction.Set(baseObject);
+                                    };
+                                    break;
                                 default:
                                     throw new ArgumentOutOfRangeException();
                             }

--- a/api/AltV.Net/Events/Events.cs
+++ b/api/AltV.Net/Events/Events.cs
@@ -68,4 +68,8 @@ namespace AltV.Net.Events
     public delegate void VehicleDetachDelegate(IVehicle target, IVehicle detachedVehicle);
     
     public delegate void VehicleDamageDelegate(IVehicle target, IEntity attacker, uint bodyHealthDamage, uint additionalBodyHealthDamage, uint engineHealthDamage, uint petrolTankDamage, uint weaponHash);
+    
+    public delegate void BaseObjectCreateDelegate(IBaseObject baseObject);
+    
+    public delegate void BaseObjectRemoveDelegate(IBaseObject baseObject);
 }

--- a/api/AltV.Net/Module.cs
+++ b/api/AltV.Net/Module.cs
@@ -154,6 +154,12 @@ namespace AltV.Net
         
         internal readonly IEventHandler<VehicleDamageDelegate> VehicleDamageEventHandler =
             new HashSetEventHandler<VehicleDamageDelegate>();
+        
+        internal readonly IEventHandler<BaseObjectCreateDelegate> BaseObjectCreateEventHandler =
+            new HashSetEventHandler<BaseObjectCreateDelegate>();
+        
+        internal readonly IEventHandler<BaseObjectRemoveDelegate> BaseObjectRemoveEventHandler =
+            new HashSetEventHandler<BaseObjectRemoveDelegate>();
 
         internal readonly IDictionary<string, Function> functionExports = new Dictionary<string, Function>();
 
@@ -1208,60 +1214,72 @@ namespace AltV.Net
         public void OnCreatePlayer(IntPtr playerPointer, ushort playerId)
         {
             PlayerPool.Create(Server, playerPointer, playerId);
+            OnBaseObjectCreate(playerPointer, BaseObjectType.Player);
         }
 
         public void OnRemovePlayer(IntPtr playerPointer)
         {
+            OnBaseObjectRemove(playerPointer, BaseObjectType.Player);
             PlayerPool.Remove(playerPointer);
         }
 
         public void OnCreateVehicle(IntPtr vehiclePointer, ushort vehicleId)
         {
             VehiclePool.Create(Server, vehiclePointer, vehicleId);
+            OnBaseObjectCreate(vehiclePointer, BaseObjectType.Vehicle);
         }
 
         public void OnCreateVoiceChannel(IntPtr channelPointer)
         {
             VoiceChannelPool.Create(Server, channelPointer);
+            OnBaseObjectCreate(channelPointer, BaseObjectType.VoiceChannel);
         }
 
         public void OnCreateColShape(IntPtr colShapePointer)
         {
             ColShapePool.Create(Server, colShapePointer);
+            OnBaseObjectCreate(colShapePointer, BaseObjectType.ColShape);
         }
 
         public void OnRemoveVehicle(IntPtr vehiclePointer)
         {
+            OnBaseObjectRemove(vehiclePointer, BaseObjectType.Vehicle);
             VehiclePool.Remove(vehiclePointer);
         }
 
         public void OnCreateBlip(IntPtr blipPointer)
         {
             BlipPool.Create(Server, blipPointer);
+            OnBaseObjectCreate(blipPointer, BaseObjectType.Blip);
         }
 
         public void OnRemoveBlip(IntPtr blipPointer)
         {
+            OnBaseObjectRemove(blipPointer, BaseObjectType.Blip);
             BlipPool.Remove(blipPointer);
         }
 
         public void OnCreateCheckpoint(IntPtr checkpointPointer)
         {
             CheckpointPool.Create(Server, checkpointPointer);
+            OnBaseObjectCreate(checkpointPointer, BaseObjectType.Checkpoint);
         }
 
         public void OnRemoveCheckpoint(IntPtr checkpointPointer)
         {
+            OnBaseObjectRemove(checkpointPointer, BaseObjectType.Checkpoint);
             CheckpointPool.Remove(checkpointPointer);
         }
 
         public void OnRemoveVoiceChannel(IntPtr channelPointer)
         {
+            OnBaseObjectRemove(channelPointer, BaseObjectType.VoiceChannel);
             VoiceChannelPool.Remove(channelPointer);
         }
 
         public void OnRemoveColShape(IntPtr colShapePointer)
         {
+            OnBaseObjectRemove(colShapePointer, BaseObjectType.ColShape);
             ColShapePool.Remove(colShapePointer);
         }
 
@@ -1696,6 +1714,66 @@ namespace AltV.Net
                 catch (Exception exception)
                 {
                     Alt.Log("exception at event:" + "OnVehicleDamageEvent" + ":" + exception);
+                }
+            }
+        }
+        
+        public void OnBaseObjectCreate(IntPtr baseObjectPointer, BaseObjectType baseObjectType)
+        {
+            if (!BaseBaseObjectPool.Get(baseObjectPointer, baseObjectType, out var baseObject))
+            {
+                Console.WriteLine("OnBaseObjectCreate Invalid baseObject " + baseObjectPointer + " " + baseObjectType);
+                return;
+            }
+
+            OnBaseObjectCreateEvent(baseObject);
+        }
+
+        public virtual void OnBaseObjectCreateEvent(IBaseObject baseObject)
+        {
+            foreach (var @delegate in BaseObjectCreateEventHandler.GetEvents())
+            {
+                try
+                {
+                    @delegate(baseObject);
+                }
+                catch (TargetInvocationException exception)
+                {
+                    Alt.Log("exception at event:" + "OnBaseObjectCreateEvent" + ":" + exception.InnerException);
+                }
+                catch (Exception exception)
+                {
+                    Alt.Log("exception at event:" + "OnBaseObjectCreateEvent" + ":" + exception);
+                }
+            }
+        }
+        
+        public void OnBaseObjectRemove(IntPtr baseObjectPointer, BaseObjectType baseObjectType)
+        {
+            if (!BaseBaseObjectPool.Get(baseObjectPointer, baseObjectType, out var baseObject))
+            {
+                Console.WriteLine("OnBaseObjectRemove Invalid baseObject " + baseObjectPointer + " " + baseObjectType);
+                return;
+            }
+
+            OnBaseObjectRemoveEvent(baseObject);
+        }
+
+        public virtual void OnBaseObjectRemoveEvent(IBaseObject baseObject)
+        {
+            foreach (var @delegate in BaseObjectRemoveEventHandler.GetEvents())
+            {
+                try
+                {
+                    @delegate(baseObject);
+                }
+                catch (TargetInvocationException exception)
+                {
+                    Alt.Log("exception at event:" + "OnBaseObjectCreateEvent" + ":" + exception.InnerException);
+                }
+                catch (Exception exception)
+                {
+                    Alt.Log("exception at event:" + "OnBaseObjectCreateEvent" + ":" + exception);
                 }
             }
         }

--- a/api/AltV.Net/ScriptEventType.cs
+++ b/api/AltV.Net/ScriptEventType.cs
@@ -30,6 +30,8 @@ namespace AltV.Net
         NetOwnerChange,
         VehicleAttach,
         VehicleDetach,
-        VehicleDamage
+        VehicleDamage,
+        BaseObjectCreate,
+        BaseObjectRemove
     }
 }


### PR DESCRIPTION
I added the triggers for the BaseObject events to the other events( OnCreatePlayer, OnRemovePlayer, OnCreateVehicle, ...).
Did this to make sure the BaseObject is available in the pool before the event is sent and also to avoid sending 2 events from the CAPI to the module.
Tested it in a local build and had no issues with it.

If you want it some other way let me know.