### PR TITLE
Adjus release action to use dev, rc and release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - id: build_info
         run: |
           branch=$(git ls-remote --heads origin | grep $GITHUB_SHA | sed "s/.*\///")
-          branch=$([[ $branch == 'master' ]] && echo "release" || [[ $branch == 'dev' ]] && echo "rc" || [[ $branch == 'alpha' ]] && echo "dev" || echo "$branch")
+          branch=$([[ $branch == 'release' ]] && echo "release" || [[ $branch == 'rc' ]] && echo "rc" || [[ $branch == 'dev' ]] && echo "dev" || echo "$branch")
           version=${GITHUB_REF##*/}
           echo "##[set-output name=branch;]$branch"
           echo "##[set-output name=version;]$version"


### PR DESCRIPTION
This changes the release workflow to use the easier understandable release pipeline dev -> rc -> release