### PR TITLE
Async CodeGen improvements

### DIFF
--- a/api/AltV.Net.Async.CodeGen/AsyncEntityGenerator.cs
+++ b/api/AltV.Net.Async.CodeGen/AsyncEntityGenerator.cs
@@ -64,34 +64,6 @@ namespace AltV.Net.Async.CodeGen {
             context.RegisterForSyntaxNotifications(() => new SyntaxTreeReceiver());
         }
 
-        private static IEnumerable<ISymbol> GetInterfaceMembers(INamedTypeSymbol @interface)
-        {
-            var members = @interface.GetMembers().ToList();
-            foreach (var namedTypeSymbol in @interface.Interfaces)
-            {
-                if (namedTypeSymbol.ToString().StartsWith("AltV.Net.Elements.Entities.")) continue;
-                foreach (var interfaceMember in GetInterfaceMembers(namedTypeSymbol))
-                {
-                    if (members.All(e => e.Name != interfaceMember.Name)) members.Add(interfaceMember);
-                }
-            }
-
-            return members;
-        }
-
-        private static IEnumerable<ISymbol> GetClassMembers(INamedTypeSymbol @class)
-        {
-            var members = @class.GetMembers().ToList();
-            if (@class.BaseType is null || @class.BaseType.ToString().StartsWith("AltV.Net.Elements.Entities."))
-                return members;
-            foreach (var classMember in GetClassMembers(@class.BaseType))
-            {
-                if (members.All(e => e.Name != classMember.Name)) members.Add(classMember);
-            }
-
-            return members;
-        }
-
         private static IList<INamedTypeSymbol> GetBaseTypes(INamedTypeSymbol @class)
         {
             var list = new List<INamedTypeSymbol>();

--- a/api/AltV.Net.Example/MyAutoAsyncPlayer.cs
+++ b/api/AltV.Net.Example/MyAutoAsyncPlayer.cs
@@ -9,22 +9,30 @@ namespace AltV.Net.Example
 {
     public partial interface IMyAutoAsyncPlayer : IPlayer
     {
-        int MyData { get; set; }
+        int MyData { get; init; }
         int CalculateOtherData();
+        int CalculateOtherData(int mod);
         bool GetSomethingToOut([MaybeNullWhen(false)] out string data);
         void GetSomethingToRef(ref int data);
         int TakeSomethingToIn(in int data);
+        void SomeNonThreadSafeMethod();
+        public long SomeNonThreadSafeProperty { get; set; }
         new void Spawn(Position position, uint delayMs = 0);
     }
 
     [AsyncEntity(typeof(IMyAutoAsyncPlayer))]
     public partial class MyAutoAsyncPlayer : Player, IMyAutoAsyncPlayer
     {
-        public int MyData { get; set; }
+        public int MyData { get; init; }
 
         public int CalculateOtherData()
         {
             return MyData * 2;
+        }
+        
+        public int CalculateOtherData(int mod)
+        {
+            return MyData * mod;
         }
 
         public bool GetSomethingToOut([MaybeNullWhen(false)] out string data)
@@ -39,6 +47,19 @@ namespace AltV.Net.Example
             return false;
         }
 
+        [AsyncProperty(ThreadSafe = true)]
+        public void SomeNonThreadSafeMethod()
+        {
+            this.SetStreamSyncedMetaData("test", 5L);
+        }
+
+        [AsyncProperty(ThreadSafe = true)]
+        public long SomeNonThreadSafeProperty
+        {
+            get => this.GetStreamSyncedMetaData("test", out long value) ? value : default;
+            set => this.SetStreamSyncedMetaData("test", value);
+        }
+        
         public void GetSomethingToRef(ref int data)
         {
             data *= 5;


### PR DESCRIPTION
- Added support for init-only setters (they used to break build)
- Added support for method overloads
- Added AsyncProperty class property attribute
  - `ThreadSafe = true` runs method or property getter safely inside RunOnMainThreadBlockingAndRunAll, setter is called inside Enqueue