### PR TITLE
BeforeConnectEvent fix

### DIFF
--- a/api/AltV.Net.Async/AltAsync.RegisterEvents.cs
+++ b/api/AltV.Net.Async/AltAsync.RegisterEvents.cs
@@ -50,7 +50,7 @@ namespace AltV.Net.Async
                                     break;
                                 case ScriptEventType.PlayerBeforeConnect:
                                     scriptFunction = ScriptFunction.Create(eventMethodDelegate,
-                                        new[] { typeof(PlayerConnectionInfo) }, true);
+                                        new[] { typeof(PlayerConnectionInfo), typeof(string) }, true);
                                     if (scriptFunction == null) return;
                                     OnPlayerBeforeConnect += (connectionInfo, reason) =>
                                     {

--- a/api/AltV.Net/Alt.RegisterEvents.cs
+++ b/api/AltV.Net/Alt.RegisterEvents.cs
@@ -46,7 +46,7 @@ namespace AltV.Net
                                     break;
                                 case ScriptEventType.PlayerBeforeConnect:
                                     scriptFunction = ScriptFunction.Create(eventMethodDelegate,
-                                        new[] { typeof(PlayerConnectionInfo) });
+                                        new[] { typeof(PlayerConnectionInfo), typeof(string) });
                                     if (scriptFunction == null) return;
                                     OnPlayerBeforeConnect += (connectionInfo, reason) =>
                                     {

--- a/api/AltV.Net/Data/PlayerConnectionInfo.cs
+++ b/api/AltV.Net/Data/PlayerConnectionInfo.cs
@@ -1,49 +1,21 @@
 using System;
 using System.Runtime.InteropServices;
+using AltV.Net.Native;
 
 namespace AltV.Net.Data
 {
-    // TODO: try use only one struct, and [MarshalAs] if strings won't be marshalled automatically
     [StructLayout(LayoutKind.Sequential)]
-    internal struct PlayerConnectionInfoInternal
+    public struct PlayerConnectionInfo
     {
-        public readonly IntPtr Name;
+        [MarshalAs(UnmanagedType.LPStr)] public readonly string Name;
         public readonly ulong SocialId;
         public readonly ulong HwidHash;
         public readonly ulong HwidExHash;
-        public readonly IntPtr AuthToken;
+        [MarshalAs(UnmanagedType.LPStr)] public readonly string AuthToken;
         public readonly bool IsDebug;
-        public readonly IntPtr Branch;
+        [MarshalAs(UnmanagedType.LPStr)] public readonly string Branch;
         public readonly uint Build;
-        public readonly IntPtr CdnUrl;
+        [MarshalAs(UnmanagedType.LPStr)] public readonly string CdnUrl;
         public readonly ulong PasswordHash;
-    }
-    
-    public class PlayerConnectionInfo
-    {
-        public readonly string Name;
-        public readonly ulong SocialId;
-        public readonly ulong HwidHash;
-        public readonly ulong HwidExHash;
-        public readonly string AuthToken;
-        public readonly bool IsDebug;
-        public readonly string Branch;
-        public readonly uint Build;
-        public readonly string CdnUrl;
-        public readonly ulong PasswordHash;
-
-        internal PlayerConnectionInfo(PlayerConnectionInfoInternal info)
-        {
-            this.Name = info.Name == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(info.Name);
-            this.SocialId = info.SocialId;
-            this.HwidHash = info.HwidHash;
-            this.HwidExHash = info.HwidExHash;
-            this.AuthToken = info.AuthToken == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(info.AuthToken);
-            this.IsDebug = info.IsDebug;
-            this.Branch = info.Branch == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(info.Branch);
-            this.Build = info.Build;
-            this.CdnUrl = info.CdnUrl == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(info.CdnUrl);
-            this.PasswordHash = info.PasswordHash;
-        }
     }
 }

--- a/api/AltV.Net/ModuleWrapper.cs
+++ b/api/AltV.Net/ModuleWrapper.cs
@@ -181,9 +181,10 @@ namespace AltV.Net
             _module.OnPlayerConnect(playerPointer, playerId, reason);
         }
 
-        public static void OnPlayerBeforeConnect(IntPtr eventPointer, PlayerConnectionInfoInternal connectionInfo, string reason)
+        public static void OnPlayerBeforeConnect(IntPtr eventPointer, IntPtr connectionInfoPointer, string reason)
         {
-            _module.OnPlayerBeforeConnect(eventPointer, new PlayerConnectionInfo(connectionInfo), reason);
+            var connectionInfo = Marshal.PtrToStructure<PlayerConnectionInfo>(connectionInfoPointer);
+            _module.OnPlayerBeforeConnect(eventPointer, connectionInfo, reason);
         }
 
         public static void OnResourceStart(IntPtr resourcePointer)

--- a/api/AltV.Net/Native/AltV.Resource.cs
+++ b/api/AltV.Net/Native/AltV.Resource.cs
@@ -24,7 +24,7 @@ namespace AltV.Net.Native
 
             internal delegate void PlayerConnectDelegate(IntPtr playerPointer, ushort playerId, string reason);
 
-            internal delegate void PlayerBeforeConnectDelegate(IntPtr eventPointer, PlayerConnectionInfoInternal connectionInfo, string reason);
+            internal delegate void PlayerBeforeConnectDelegate(IntPtr eventPointer, IntPtr connectionInfo, string reason);
 
             internal delegate void ResourceEventDelegate(IntPtr resourcePointer);
 

--- a/runtime/src/CSharpResourceImpl.cpp
+++ b/runtime/src/CSharpResourceImpl.cpp
@@ -163,11 +163,12 @@ bool CSharpResourceImpl::OnEvent(const alt::CEvent* ev) {
             break;
         case alt::CEvent::Type::PLAYER_BEFORE_CONNECT: {
             auto beforeConnectEvent = (alt::CPlayerBeforeConnectEvent*)ev;
-            auto clrInfo = ClrConnectionInfo(beforeConnectEvent->GetConnectionInfo());
+            auto clrInfo = new ClrConnectionInfo(beforeConnectEvent->GetConnectionInfo());
 
-            OnPlayerBeforeConnectDelegate(beforeConnectEvent, &clrInfo, beforeConnectEvent->GetReason().c_str());
+            OnPlayerBeforeConnectDelegate(beforeConnectEvent, clrInfo, beforeConnectEvent->GetReason().c_str());
 
-            clrInfo.dealloc();
+            clrInfo->dealloc();
+            delete clrInfo;
         }
             break;
         case alt::CEvent::Type::RESOURCE_START: {


### PR DESCRIPTION
The main problem was in the fact, that pointer of a stack struct was passed. Allocating the struct on heap and then destroying it (and all the strings inside) after the call (even without separate c method call from c#) seems to be working pretty ok for those guys, that had those crashes. FIRE_EVENT data is also destroyed right after the  delegate call, so i guess that should be safe enough to do that.