### PR TITLE
Update usage of (uint) stuff

### DIFF
--- a/api/AltV.Net.Async/Elements/Entities/AsyncPlayer.cs
+++ b/api/AltV.Net.Async/Elements/Entities/AsyncPlayer.cs
@@ -401,7 +401,7 @@ namespace AltV.Net.Async.Elements.Entities
         }
         
         public void GiveWeapon(WeaponModel weapon, int ammo, bool selectWeapon)
-                 => GiveWeapon((uint)weapon, int ammo, bool selectWeapon);
+                 => GiveWeapon((uint)weapon, ammo, selectWeapon);
         
         public void GiveWeapon(uint weapon, int ammo, bool selectWeapon)
         {

--- a/api/AltV.Net.Async/Elements/Entities/AsyncPlayer.cs
+++ b/api/AltV.Net.Async/Elements/Entities/AsyncPlayer.cs
@@ -391,17 +391,26 @@ namespace AltV.Net.Async.Elements.Entities
         {
             AsyncContext.Enqueue(() => BaseObject.SetDateTime(day, month, year, hour, minute, second));
         }
-
+        
+        public void SetWeather(WeatherType weather)
+                 => SetWeather((uint)weather);
+        
         public void SetWeather(uint weather)
         {
             AsyncContext.Enqueue(() => BaseObject.SetWeather(weather));
         }
-
+        
+        public void GiveWeapon(WeaponModel weapon, int ammo, bool selectWeapon)
+                 => GiveWeapon((uint)weapon, int ammo, bool selectWeapon);
+        
         public void GiveWeapon(uint weapon, int ammo, bool selectWeapon)
         {
             AsyncContext.Enqueue(() => BaseObject.GiveWeapon(weapon, ammo, selectWeapon));
         }
 
+        public bool RemoveWeapon(WeaponModel weapon)
+                 => RemoveWeapon((uint)weapon); 
+                 
         public bool RemoveWeapon(uint weapon)
         {
             bool result = default;


### PR DESCRIPTION
instead of always using the type (uint)Enum after it, you could simply have 2 methods either you use the provided enum data or uint. I gave a example on this propose. has to be done on all other methods.