### PR TITLE
Added parsers for sbyte, short, byte and ushort

### DIFF
--- a/api/AltV.Net/FunctionParser/FunctionMValueConstParsers.cs
+++ b/api/AltV.Net/FunctionParser/FunctionMValueConstParsers.cs
@@ -269,7 +269,7 @@ namespace AltV.Net.FunctionParser
 
             if (mValue.type == MValueConst.Type.Uint)
             {
-                return (int) mValue.GetUint();
+                return (long) mValue.GetUint();
             }
 
             // Types doesn't match

--- a/api/AltV.Net/FunctionParser/FunctionMValueConstParsers.cs
+++ b/api/AltV.Net/FunctionParser/FunctionMValueConstParsers.cs
@@ -242,6 +242,40 @@ namespace AltV.Net.FunctionParser
             return null;
         }
 
+        public static object ParseSByte(in MValueConst mValue, Type type,
+            FunctionTypeInfo typeInfo)
+        {
+            if (mValue.type == MValueConst.Type.Int)
+            {
+                return (sbyte) mValue.GetInt();
+            }
+
+            if (mValue.type == MValueConst.Type.Uint)
+            {
+                return (sbyte) mValue.GetUint();
+            }
+
+            // Types doesn't match
+            return null;
+        }
+
+        public static object ParseShort(in MValueConst mValue, Type type,
+            FunctionTypeInfo typeInfo)
+        {
+            if (mValue.type == MValueConst.Type.Int)
+            {
+                return (short) mValue.GetInt();
+            }
+
+            if (mValue.type == MValueConst.Type.Uint)
+            {
+                return (short) mValue.GetUint();
+            }
+
+            // Types doesn't match
+            return null;
+        }
+
         public static object ParseInt(in MValueConst mValue, Type type,
             FunctionTypeInfo typeInfo)
         {
@@ -270,6 +304,40 @@ namespace AltV.Net.FunctionParser
             if (mValue.type == MValueConst.Type.Uint)
             {
                 return (long) mValue.GetUint();
+            }
+
+            // Types doesn't match
+            return null;
+        }
+
+        public static object ParseByte(in MValueConst mValue, Type type,
+            FunctionTypeInfo typeInfo)
+        {
+            if (mValue.type == MValueConst.Type.Uint)
+            {
+                return (byte) mValue.GetUint();
+            }
+
+            if (mValue.type == MValueConst.Type.Int)
+            {
+                return (byte) mValue.GetInt();
+            }
+
+            // Types doesn't match
+            return null;
+        }
+
+        public static object ParseUShort(in MValueConst mValue, Type type,
+            FunctionTypeInfo typeInfo)
+        {
+            if (mValue.type == MValueConst.Type.Uint)
+            {
+                return (ushort) mValue.GetUint();
+            }
+
+            if (mValue.type == MValueConst.Type.Int)
+            {
+                return (ushort) mValue.GetInt();
             }
 
             // Types doesn't match

--- a/api/AltV.Net/FunctionParser/FunctionObjectParsers.cs
+++ b/api/AltV.Net/FunctionParser/FunctionObjectParsers.cs
@@ -55,6 +55,38 @@ namespace AltV.Net.FunctionParser
             return null;
         }
 
+        public static object ParseSByte(object value, Type type, FunctionTypeInfo typeInfo)
+        {
+            unchecked
+            {
+                return value switch
+                {
+                    long longValue => (sbyte) longValue,
+                    ulong ulongValue => (sbyte) ulongValue,
+                    double doubleValue => (sbyte) doubleValue,
+                    string stringValue when sbyte.TryParse(stringValue, out var sbyteValue) => sbyteValue,
+                    bool boolValue => boolValue ? (sbyte) 1 : (sbyte) 0,
+                    _ => default
+                };
+            }
+        }
+
+        public static object ParseShort(object value, Type type, FunctionTypeInfo typeInfo)
+        {
+            unchecked
+            {
+                return value switch
+                {
+                    long longValue => (short) longValue,
+                    ulong ulongValue => (short) ulongValue,
+                    double doubleValue => (short) doubleValue,
+                    string stringValue when short.TryParse(stringValue, out var shortValue) => shortValue,
+                    bool boolValue => boolValue ? (short) 1 : (short) 0,
+                    _ => default
+                };
+            }
+        }
+
         public static object ParseInt(object value, Type type, FunctionTypeInfo typeInfo)
         {
             unchecked
@@ -87,6 +119,38 @@ namespace AltV.Net.FunctionParser
             }
         }
 
+        public static object ParseByte(object value, Type type, FunctionTypeInfo typeInfo)
+        {
+            unchecked
+            {
+                return value switch
+                {
+                    long longValue => (byte) longValue,
+                    ulong ulongValue => (byte) ulongValue,
+                    double doubleValue => (byte) doubleValue,
+                    string stringValue when byte.TryParse(stringValue, out var byteValue) => byteValue,
+                    bool boolValue => boolValue ? (byte) 1 : (byte) 0,
+                    _ => default
+                };
+            }
+        }
+
+        public static object ParseUShort(object value, Type type, FunctionTypeInfo typeInfo)
+        {
+            unchecked
+            {
+                return value switch
+                {
+                    long longValue => (ushort) longValue,
+                    ulong ulongValue => (ushort) ulongValue,
+                    double doubleValue => (ushort) doubleValue,
+                    string stringValue when ushort.TryParse(stringValue, out var ushortValue) => ushortValue,
+                    bool boolValue => boolValue ? (ushort) 1 : (ushort) 0,
+                    _ => default
+                };
+            }
+        }
+
         public static object ParseUInt(object value, Type type, FunctionTypeInfo typeInfo)
         {
             unchecked
@@ -97,7 +161,7 @@ namespace AltV.Net.FunctionParser
                     ulong ulongValue => (uint) ulongValue,
                     double doubleValue => (uint) doubleValue,
                     string stringValue when uint.TryParse(stringValue, out var uintValue) => uintValue,
-                    bool boolValue => boolValue ? (uint) 1 : (uint) 0,
+                    bool boolValue => boolValue ? 1U : 0U,
                     _ => default
                 };
             }
@@ -113,7 +177,7 @@ namespace AltV.Net.FunctionParser
                     ulong ulongValue => ulongValue,
                     double doubleValue => (ulong) doubleValue,
                     string stringValue when ulong.TryParse(stringValue, out var ulongValue) => ulongValue,
-                    bool boolValue => boolValue ? (ulong) 1L : (ulong) 0L,
+                    bool boolValue => boolValue ? 1UL : 0UL,
                     _ => default
                 };
             }
@@ -129,7 +193,7 @@ namespace AltV.Net.FunctionParser
                     ulong ulongValue => (float) ulongValue,
                     double doubleValue => (float) doubleValue,
                     string stringValue when float.TryParse(stringValue, out var floatValue) => floatValue,
-                    bool boolValue => boolValue ? (float) 1.0 : (float) 0.0,
+                    bool boolValue => boolValue ? 1.0f : 0.0f,
                     _ => default
                 };
             }
@@ -143,9 +207,9 @@ namespace AltV.Net.FunctionParser
                 {
                     long longValue => (double) longValue,
                     ulong ulongValue => (double) ulongValue,
-                    double doubleValue => (double) doubleValue,
+                    double doubleValue => doubleValue,
                     string stringValue when double.TryParse(stringValue, out var doubleValue) => doubleValue,
-                    bool boolValue => boolValue ? (double) 1.0 : (double) 0.0,
+                    bool boolValue => boolValue ? 1.0 : 0.0,
                     _ => default
                 };
             }

--- a/api/AltV.Net/FunctionParser/FunctionStringParsers.cs
+++ b/api/AltV.Net/FunctionParser/FunctionStringParsers.cs
@@ -21,6 +21,18 @@ namespace AltV.Net.FunctionParser
             return boolValue;
         }
 
+        public static object ParseSByte(string value, Type type, FunctionTypeInfo typeInfo)
+        {
+            if (!sbyte.TryParse(value, out var sbyteValue)) return null;
+            return sbyteValue;
+        }
+
+        public static object ParseShort(string value, Type type, FunctionTypeInfo typeInfo)
+        {
+            if (!short.TryParse(value, out var shortValue)) return null;
+            return shortValue;
+        }
+
         public static object ParseInt(string value, Type type, FunctionTypeInfo typeInfo)
         {
             if (!int.TryParse(value, out var intValue)) return null;
@@ -31,6 +43,18 @@ namespace AltV.Net.FunctionParser
         {
             if (!long.TryParse(value, out var longValue)) return null;
             return longValue;
+        }
+
+        public static object ParseByte(string value, Type type, FunctionTypeInfo typeInfo)
+        {
+            if (!byte.TryParse(value, out var byteValue)) return null;
+            return byteValue;
+        }
+
+        public static object ParseUShort(string value, Type type, FunctionTypeInfo typeInfo)
+        {
+            if (!ushort.TryParse(value, out var ushortValue)) return null;
+            return ushortValue;
         }
 
         public static object ParseUInt(string value, Type type, FunctionTypeInfo typeInfo)

--- a/api/AltV.Net/FunctionParser/FunctionTypeInfo.cs
+++ b/api/AltV.Net/FunctionParser/FunctionTypeInfo.cs
@@ -199,6 +199,18 @@ namespace AltV.Net.FunctionParser
                 ObjectParser = FunctionObjectParsers.ParseBool;
                 StringParser = FunctionStringParsers.ParseBool;
             }
+            else if (paramType == FunctionTypes.SByte)
+            {
+                ConstParser = FunctionMValueConstParsers.ParseSByte;
+                ObjectParser = FunctionObjectParsers.ParseSByte;
+                StringParser = FunctionStringParsers.ParseSByte;
+            }
+            else if (paramType == FunctionTypes.Short)
+            {
+                ConstParser = FunctionMValueConstParsers.ParseShort;
+                ObjectParser = FunctionObjectParsers.ParseShort;
+                StringParser = FunctionStringParsers.ParseShort;
+            }
             else if (paramType == FunctionTypes.Int)
             {
                 ConstParser = FunctionMValueConstParsers.ParseInt;
@@ -210,6 +222,18 @@ namespace AltV.Net.FunctionParser
                 ConstParser = FunctionMValueConstParsers.ParseLong;
                 ObjectParser = FunctionObjectParsers.ParseLong;
                 StringParser = FunctionStringParsers.ParseLong;
+            }
+            else if (paramType == FunctionTypes.Byte)
+            {
+                ConstParser = FunctionMValueConstParsers.ParseByte;
+                ObjectParser = FunctionObjectParsers.ParseByte;
+                StringParser = FunctionStringParsers.ParseByte;
+            }
+            else if (paramType == FunctionTypes.UShort)
+            {
+                ConstParser = FunctionMValueConstParsers.ParseUShort;
+                ObjectParser = FunctionObjectParsers.ParseUShort;
+                StringParser = FunctionStringParsers.ParseUShort;
             }
             else if (paramType == FunctionTypes.UInt)
             {

--- a/api/AltV.Net/FunctionParser/FunctionTypes.cs
+++ b/api/AltV.Net/FunctionParser/FunctionTypes.cs
@@ -11,9 +11,17 @@ namespace AltV.Net.FunctionParser
 
         public static readonly Type Bool = typeof(bool);
 
+        public static readonly Type SByte = typeof(sbyte);
+
+        public static readonly Type Short = typeof(short);
+
         public static readonly Type Int = typeof(int);
 
         public static readonly Type Long = typeof(long);
+
+        public static readonly Type Byte = typeof(byte);
+
+        public static readonly Type UShort = typeof(ushort);
 
         public static readonly Type UInt = typeof(uint);
 


### PR DESCRIPTION
I added parsers for sbyte, short, byte and ushort so that you can directly use those types in ClientEvent methods.

I also found a minor bug, see a357a9910c8048e8ee1b31cf917893fd036c06d0.