### PR TITLE
rename Wastlndr to Wastelander

### DIFF
--- a/api/AltV.Net/Enums/VehicleModel.cs
+++ b/api/AltV.Net/Enums/VehicleModel.cs
@@ -345,7 +345,7 @@ namespace AltV.Net.Enums
         RapidGt = 2360515092,
         Windsor2 = 2364918497,
         Insurgent3 = 2370534026,
-        Wastlander = 2382949506,
+        Wastelander = 2382949506,
         Asterope = 2391954683,
         Surge = 2400073108,
         Premier = 2411098011,

--- a/api/AltV.Net/Enums/VehicleModel.cs
+++ b/api/AltV.Net/Enums/VehicleModel.cs
@@ -345,7 +345,7 @@ namespace AltV.Net.Enums
         RapidGt = 2360515092,
         Windsor2 = 2364918497,
         Insurgent3 = 2370534026,
-        Wastlndr = 2382949506,
+        Wastlander = 2382949506,
         Asterope = 2391954683,
         Surge = 2400073108,
         Premier = 2411098011,


### PR DESCRIPTION
When use the string name "wastlndr" you see a error. So, I think it's better to use Wastlander in the enum name too. All the others work "normally" with the enum.