### PR TITLE
Fixes #580

### DIFF
--- a/api/AltV.Net.Async.CodeGen/AsyncEntityGenerator.cs
+++ b/api/AltV.Net.Async.CodeGen/AsyncEntityGenerator.cs
@@ -358,7 +358,7 @@ public partial class {@class.Name}{classBaseDeclaration} {{
     }}
 
     private class Async : {asyncEntityType}<{@interface}>, {@interface} {{
-        public Async({@interface} player, AltV.Net.Async.IAsyncContext asyncContext) : base(player, asyncContext) {{ }}
+        public Async({@interface} player, AltV.Net.Async.IAsyncContext? asyncContext) : base(player, asyncContext) {{ }}
 
         public {@interface} ToAsync(AltV.Net.Async.IAsyncContext asyncContext) {{
             return asyncContext == AsyncContext ? this : new Async(BaseObject, asyncContext);


### PR DESCRIPTION
Since there are cases where no async context is required to get the async version of the entity, it can be nullable.
I wonder if I should update this in `AsyncEntity<>` base class and other derived classes too, but this one line in the generator should simply fix the warning.