### PR TITLE
Update IServer references to ICore on docs

### DIFF
--- a/docs/articles/getting-started/entity-factories.md
+++ b/docs/articles/getting-started/entity-factories.md
@@ -12,7 +12,7 @@ public class MyPlayer : Player
 {
   public bool LoggedIn { get; set; }
   
-  public MyPlayer(IServer server, IntPtr nativePointer, ushort id) : base(server, nativePointer, id)
+  public MyPlayer(ICore server, IntPtr nativePointer, ushort id) : base(server, nativePointer, id)
   {
     LoggedIn = false;
   }
@@ -30,7 +30,7 @@ You only need to override the ```IPlayer Create(IntPtr playerPointer, ushort id)
 ```csharp
 public class MyPlayerFactory : IEntityFactory<IPlayer>
 {
-  public IPlayer Create(IServer server, IntPtr playerPointer, ushort id)
+  public IPlayer Create(ICore server, IntPtr playerPointer, ushort id)
   {
     return new MyPlayer(server, playerPointer, id);
   }
@@ -66,13 +66,13 @@ public class MyVehicle : Vehicle
         public int MyData { get; set; }
 
         // This constructor is used for creation via constructor
-        public MyVehicle(IServer server, uint model, Position position, Rotation rotation) : base(server, model, position, rotation)
+        public MyVehicle(ICore server, uint model, Position position, Rotation rotation) : base(server, model, position, rotation)
         {
             MyData = 7;
         }
 
         // This constructor is used for creation via entity factory
-        public MyVehicle(IServer server, IntPtr nativePointer, ushort id) : base(server, nativePointer, id)
+        public MyVehicle(ICore server, IntPtr nativePointer, ushort id) : base(server, nativePointer, id)
         {
             MyData = 6;
         }


### PR DESCRIPTION
This breaking change was introduced in 10.0 ([changelog](https://docs.altv.mp/articles/changelogs/index.html#breaking-changes-1)) and so I updated the docs to match the new terminology.