### PR TITLE
Fix warning CS0108 of AsyncEntityGenerator

### DIFF
--- a/api/AltV.Net.Async.CodeGen/AsyncEntityGenerator.cs
+++ b/api/AltV.Net.Async.CodeGen/AsyncEntityGenerator.cs
@@ -364,7 +364,7 @@ public partial class {@class.Name}{classBaseDeclaration} {{
 
         private readonly {@interface} CustomBaseObject;
 
-        public {@interface} ToAsync(AltV.Net.Async.IAsyncContext asyncContext) {{
+        public new {@interface} ToAsync(AltV.Net.Async.IAsyncContext asyncContext) {{
             return asyncContext == AsyncContext ? this : new Async(CustomBaseObject, asyncContext);
         }}
 


### PR DESCRIPTION
This line in the generated async entity code produces the warning.
```csharp
public MyNamespace.Players.IPlayer ToAsync(AltV.Net.Async.IAsyncContext asyncContext) {
    // ^^^^^^ warning CS0108: 'Player.Async.ToAsync(IAsyncContext)' hides inherited member 'AsyncPlayer.ToAsync(IAsyncContext)'. Use the new keyword if hiding was intended.
    return asyncContext == AsyncContext ? this : new Async(CustomBaseObject, asyncContext);
}
```
I added `new` to explicitly hide it.