### PR TITLE
fixed GetBaseObjectById cast error

### DIFF
--- a/api/AltV.Net.Shared/SharedCore.cs
+++ b/api/AltV.Net.Shared/SharedCore.cs
@@ -265,10 +265,10 @@ namespace AltV.Net.Shared
             unsafe
             {
                 CheckIfCallIsValid();
-                var entityPointer = Library.Shared.Core_GetBaseObjectByID(NativePointer, (byte)type, (ushort)id);
+                var entityPointer = Library.Shared.Core_GetBaseObjectByID(NativePointer, (byte)type, id);
                 if (entityPointer == IntPtr.Zero) return null;
 
-                return (ISharedEntity)PoolManager.Get(entityPointer, type);
+                return PoolManager.Get(entityPointer, type);
             }
         }
 


### PR DESCRIPTION
fixed error when using GetBaseObjectById

```
Unable to cast object of type 'AltV.Net.Client.Elements.Entities.Marker' to type 'AltV.Net.Shared.Elements.Entities.ISharedEntity'.
   at AltV.Net.Shared.SharedCore.GetBaseObjectById(BaseObjectType type, UInt32 id) in F:\coreclr-module\api\AltV.Net.Shared\SharedCore.cs:line 271
   at AltV.Net.Client.Core.GetBaseObjectById(BaseObjectType type, UInt32 id) in F:\coreclr-module\api\AltV.Net.Client\Core.cs:line 197
   at AltV.Net.Client.Alt.GetBaseObjectById(BaseObjectType type, UInt32 id, IBaseObject& baseObject) in F:\coreclr-module\api\AltV.Net.Client\Alt.cs:line 26
   at TestResource_Server.Main.Alt_OnConsoleCommand(String name, String[] args) in F:\altV Playground\work\TestResource\TestResource Client\Main.cs:line 28
   at AltV.Net.Client.Core.<>c__DisplayClass172_0.<OnConsoleCommand>b__0(ConsoleCommandDelegate fn) in F:\coreclr-module\api\AltV.Net.Client\Core.Events.cs:line 227
   at AltV.Net.Client.Extensions.EnumerableExtensions.ForEachCatching[T](IEnumerable`1 enumerable, Action`1 action, String exceptionLocation) in F:\coreclr-module\api\AltV.Net.Client\Extensions\EnumerableExtensions.cs:line 13
```