### PR TITLE
add async entity factories. improve docs for both

### DIFF
--- a/docs/articles/getting-started/async-entity-factories.md
+++ b/docs/articles/getting-started/async-entity-factories.md
@@ -2,19 +2,19 @@
 
 Entity factories allows you to optimize your server performance by defining the data you need to store in a player or vehicle on compile time. This allows much faster data access than via .SetData, ```.GetData```.
 
-**NOTE: For gamemodes extending ``AsyncResource``, please read [Async Entity Factories](async-entity-factories.md).**
+**NOTE: For gamemodes extending ``Resource``, please read [Entity Factories](entity-factories.md).**
 
 ## Step 1, Create the class
 
-Defining your custom player or vehicle class by extending ```Player``` or ```Vehicle```.
-You need to implement the default constructor of ```Player``` or ```Vehicle``` as well. 
+Defining your custom player or vehicle class by extending ```AsyncPlayer``` or ```AsyncVehicle```.
+You need to implement the default constructor of ```AsyncPlayer``` or ```AsyncVehicle``` as well. 
 
 ```csharp
-public class MyPlayer : Player
+public class MyAsyncPlayer : AsyncPlayer
 {
   public bool LoggedIn { get; set; }
   
-  public MyPlayer(ICore core, IntPtr nativePointer, ushort id) : base(core, nativePointer, id)
+  public MyAsyncPlayer(ICore core, IntPtr nativePointer, ushort id) : base(core, nativePointer, id)
   {
     LoggedIn = false;
   }
@@ -30,11 +30,11 @@ In the factory the defined default constructor of the player or vehicle class wi
 You only need to override the ```IPlayer Create(IntPtr playerPointer, ushort id)``` method and initialize your own class instead of the default one.
 
 ```csharp
-public class MyPlayerFactory : IEntityFactory<IPlayer>
+public class MyAsyncPlayerFactory : IEntityFactory<IPlayer>
 {
   public IPlayer Create(ICore core, IntPtr playerPointer, ushort id)
   {
-    return new MyPlayer(core, playerPointer, id);
+    return new MyAsyncPlayer(core, playerPointer, id);
   }
 }
 ```
@@ -46,10 +46,10 @@ You simply do this by overriding ```IEntityFactory<IPlayer> GetPlayerFactory()``
 This will look like the code below.
 
 ```csharp
-public class SampleResource : Resource {
+public class SampleResource : AsyncResource {
   public override IEntityFactory<IPlayer> GetPlayerFactory()
   {
-      return new MyPlayerFactory();
+      return new MyAsyncPlayerFactory();
   }
 }
 ```
@@ -58,17 +58,19 @@ public class SampleResource : Resource {
 
 It works the same for vehicles, eg:
 ```csharp
-public class MyVehicle : Vehicle
+public class MyAsyncVehicle : AsyncVehicle
     {
         public int MyData { get; set; }
 
         // This constructor is used for creation via entity factory
-        public MyVehicle(ICore core, IntPtr nativePointer, ushort id) : base(core, nativePointer, id)
+        public MyAsyncVehicle(ICore core, IntPtr nativePointer, ushort id) : base(core, nativePointer, id)
         {
             MyData = 6;
         }
 }
 ```
+
+
 
 ## Use the custom Entity class
 
@@ -77,7 +79,7 @@ For events inside IScript class you can just use your own class instead of IPlay
 ```csharp
 public class SampleScript: IScript {
   [ScriptEvent(ScriptEventType.PlayerConnect)]
-  public void MyPlayerConnect(MyPlayer player, string reason)
+  public void MyPlayerConnect(MyAsyncPlayer player, string reason)
   {
    //...
   }
@@ -87,11 +89,11 @@ public class SampleScript: IScript {
 For events registered via Alt you can just cast the entities to the custom classes.
 
 ```csharp
-Alt.OnPlayerConnect += OnPlayerConnect;
+AltAsync.OnPlayerConnect += OnPlayerConnect;
 //...
-private void OnPlayerConnect(IPlayer player, string reason)
+private async Task OnPlayerConnect(IPlayer player, string reason)
 {
-  var myPlayer = (MyPlayer)player;
+  var myPlayer = (MyAsyncPlayer)player;
   //...
 }
 ```

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -15,6 +15,8 @@
       href: getting-started/resource-communication.md
     - name: Entity factories
       href: getting-started/entity-factories.md
+    - name: Async Entity factories
+      href: getting-started/async-entity-factories.md
     - name: Entity data
       href: getting-started/entity-data.md
     - name: Async


### PR DESCRIPTION
Added a new article that explains how entity factories work with async entities.
Improved both files by removing some redundant/outdated info.
Removed the extra explanation for vehicles since you can't create them via constructor anymore in v15.

edited it pretty quickly, I may have missed something here and there. Let me know if I did and I'll fix it :)