### PR TITLE
Add overload for Alt.LogColored(string)

### DIFF
--- a/api/AltV.Net/Alt.Log.Colored.cs
+++ b/api/AltV.Net/Alt.Log.Colored.cs
@@ -4,6 +4,7 @@ namespace AltV.Net
 {
     public static partial class Alt
     {
+        public static void LogColored(string message) => Core.LogColored(message);
         public static void LogColored(ColoredMessage message) => Core.LogColored(message.ToString());
     }
 }


### PR DESCRIPTION
This PR exposes `Alt.LogColored(string message)` to the `Alt` namespace - previously, you would have to call the method from `Alt.Core`